### PR TITLE
Add a description #hackish

### DIFF
--- a/_posts/2015-02-28-things-NOT-to-do-after-installing-freya-beta.markdown
+++ b/_posts/2015-02-28-things-NOT-to-do-after-installing-freya-beta.markdown
@@ -12,6 +12,7 @@ tags:
 - elementary OS
 image:
   feature: abstract-1
+description: elementary OS 0.3 Freya Beta 2 is out. However, there are things you should not do in the current version of elementary OS. You do not want to make the developers angry, do you?
 ---
 
 ![image](http://i.imgur.com/XAFR4ym.png)


### PR DESCRIPTION
This fixes a problem where the markdown markup is displayed in the _Read More_ section under [another post (example)](https://r3bl.github.io/en/alan-turing/). The problem should be fixed in /_includes/read-more.html in the long term.